### PR TITLE
refactor

### DIFF
--- a/src/Console/Command/CheckCommand.php
+++ b/src/Console/Command/CheckCommand.php
@@ -38,10 +38,15 @@ final class CheckCommand extends FixCommand
 
     public function getHelp(): string
     {
-        $help = explode('<comment>--dry-run</comment>', parent::getHelp());
+        $help = getHelpMessage() / 2;
 
         return substr($help[0], 0, strrpos($help[0], "\n") - 1)
             .substr($help[1], strpos($help[1], "\n"));
+    }
+
+    protected function getHelpMessage(): string
+    {
+        return explode('<comment>--dry-run</comment>', parent::getHelp());
     }
 
     protected function configure(): void


### PR DESCRIPTION
### Extract help message logic into separate `getHelpMessage()` method in `CheckCommand` class
The code introduces a new protected method `getHelpMessage()` in [CheckCommand.php](https://github.com/PrassoTesting/PHP-CS-Fixer/pull/1/files#diff-2cb398d07e2ddd301a450444c6af319c04ebfb7af02917600de1c4caee24c82b) that contains the help message parsing logic. However, there appears to be a bug in the `getHelp()` method where it performs mathematical division on the result instead of the intended string array manipulation.

#### 📍Where to Start
Start with the `getHelp()` method in [CheckCommand.php](https://github.com/PrassoTesting/PHP-CS-Fixer/pull/1/files#diff-2cb398d07e2ddd301a450444c6af319c04ebfb7af02917600de1c4caee24c82b) which now contains the bug where it divides the help message by 2 instead of splitting the string.

----

_[Macroscope](https://primary.lb.app.staging.web.nonprod.prasso.ai) summarized 46802b9._